### PR TITLE
Fix: user_id of refresh token update on generate access_token : invalid authenticate Get #1

### DIFF
--- a/src/main/java/Production/AuthService/controllers/AuthController.java
+++ b/src/main/java/Production/AuthService/controllers/AuthController.java
@@ -220,6 +220,8 @@ public class AuthController {
 
         // 1️⃣ Cookie (preferred)
         if (request.getCookies() != null) {
+
+            System.out.println(Arrays.toString(request.getCookies()) +"this is cookie that get ==referesh token");
 //            for (Cookie cookie : request.getCookies()) {
 //                if ("refresh_token".equals(cookie.getName())
 //                        && cookie.getValue() != null

--- a/src/main/java/Production/AuthService/controllers/AuthController.java
+++ b/src/main/java/Production/AuthService/controllers/AuthController.java
@@ -138,9 +138,9 @@ public class AuthController {
             throw new InvalidResourceFoundException("Token expired");
         }
 
-//        if(storedRefreshToken.getUser().getId().equals(userId)){
-//            throw new InvalidResourceFoundException("Invalid User");
-//        }
+        if(storedRefreshToken.getUser().getId().equals(userId)){
+            throw new InvalidResourceFoundException("Invalid User");
+        }
 
         //refresh token rotate
         storedRefreshToken.setRevoked(true);

--- a/src/main/java/Production/AuthService/entities/RefreshToken.java
+++ b/src/main/java/Production/AuthService/entities/RefreshToken.java
@@ -25,7 +25,7 @@ public class RefreshToken {
     @Column(name = "jti",unique = true,nullable = false)
     private String jti;
 
-    @ManyToOne(optional = false,fetch = FetchType.LAZY)
+    @ManyToOne(optional = false,fetch = FetchType.EAGER)
     @JoinColumn(name = "user_id",nullable = false)
     private User user;
 


### PR DESCRIPTION
- user load as eager method in refresh token model

## Summary by Sourcery

Validate refresh token ownership against the requesting user and adjust token loading behavior to prevent incorrect authentication during access token generation.

Bug Fixes:
- Re-enable validation that the refresh token's associated user matches the requesting user before issuing a new access token.
- Change the refresh token's user relation to be eagerly loaded to avoid missing user data during refresh token processing.

Enhancements:
- Log incoming cookies when reading the refresh token from the HTTP request to aid debugging of refresh token retrieval issues.