### PR TITLE
debug: refresh token invalid user

### DIFF
--- a/src/main/java/Production/AuthService/Constant/PublicURLs.java
+++ b/src/main/java/Production/AuthService/Constant/PublicURLs.java
@@ -21,7 +21,8 @@ public class PublicURLs {
 
     // 🔓 Authentication Endpoints
     public static final String[] AUTH = {
-            "/api/auth/**"
+            "/api/auth/login",
+            "/api/auth/register"
     };
 
     // 🔓 OAuth2 Endpoints

--- a/src/main/java/Production/AuthService/SecurityUtils/JwtService.java
+++ b/src/main/java/Production/AuthService/SecurityUtils/JwtService.java
@@ -90,10 +90,14 @@ public class JwtService {
         Instant now = Instant.now();
         Instant expiry = now.plusSeconds(refreshTTL);
 
+//        List<String> roles = user.getRoles()
+//                .stream()
+//                .map(Role::getName)   // or role.getRoleName()
+//                .collect(Collectors.toList());
         List<String> roles = user.getRoles()
                 .stream()
-                .map(Role::getName)   // or role.getRoleName()
-                .collect(Collectors.toList());
+                .map(role -> "ROLE_" + role.getName())
+                .toList();
 
         return Jwts.builder()
                 .issuer(issuer)

--- a/src/main/java/Production/AuthService/config/SecurityConfig.java
+++ b/src/main/java/Production/AuthService/config/SecurityConfig.java
@@ -65,12 +65,13 @@ public class SecurityConfig {
                         .requestMatchers(PublicURLs.ALL_PUBLIC_URL).permitAll()
 
                         // 1️⃣ CREATE → only DEVELOPER
-                        .requestMatchers(HttpMethod.POST, "/api/v3/user/**")
+                        .requestMatchers(HttpMethod.POST, "/api/v3/user/**","/api/v3/auth/refresh")
                         .hasRole("DEVELOPER")
 
                         // 2️⃣ GET ALL → only ADMIN & DEVELOPER
                         .requestMatchers(HttpMethod.GET, "/api/v3/user/**")
                         .hasAnyRole("ADMIN", "DEVELOPER")
+
 
                         // Everything else must be authenticated
                         .anyRequest().authenticated()

--- a/src/main/java/Production/AuthService/controllers/AuthController.java
+++ b/src/main/java/Production/AuthService/controllers/AuthController.java
@@ -77,6 +77,8 @@ public class AuthController {
                 .build();
         refreshTokenRepository.save(refreshTokendb);
 
+        log.info(jti+"this is jti that gen for refresh token"+refreshTokendb.getJti());
+
 
         //generate token
         String accessToken = jwtService.generateAccessToken(user);
@@ -84,6 +86,7 @@ public class AuthController {
 
         //attach cookies
         cookieService.attachRefreshTokenCookie(response,refreshToken,(int)jwtService.getRefreshTTL());
+        log.info( user.getId()+"Cookes attactched to response" +refreshToken);
         cookieService.addNoStoreHeaders(response);
 
 
@@ -122,13 +125,14 @@ public class AuthController {
         //read token from cookie
 
         String refreshTokenfromRequest =readRefreshTokenFromRequest(refreshTokenRequest,request).orElseThrow(()->new InvalidResourceFoundException("Refresh token missing"));
+        log.info(refreshTokenfromRequest+"refreshTOken from request cookies");
         if(jwtService.validateRefreshToken(refreshTokenfromRequest).isEmpty()){
             throw new InvalidResourceFoundException("Invalid Cred;");
         }
 
         String jti = jwtService.extractRefreshTokenId(refreshTokenfromRequest);
         UUID userId =jwtService.extractUserIdFromRefreshToken(refreshTokenfromRequest);
-        log.info(userId+"this is user id from refresh token");
+        log.info(userId+"this is user id from refresh token"+jti);
         RefreshToken storedRefreshToken =refreshTokenRepository.findByJti(jti).orElseThrow(()-> new InvalidResourceFoundException("Invalid Cred;"));
         log.info(storedRefreshToken+"stored refresh token");
         if(storedRefreshToken.isRevoked()){
@@ -139,9 +143,11 @@ public class AuthController {
             throw new InvalidResourceFoundException("Token expired");
         }
 
-//        if(storedRefreshToken.getUser().getId().equals(userId)){
-//            throw new InvalidResourceFoundException("Invalid User");
-//        }
+        if(!storedRefreshToken.getUser().getId().equals(userId)){
+            log.info(storedRefreshToken.getUser().getId()+"this is stored userid");
+            log.info(userId+"this is  userid");
+            throw new InvalidResourceFoundException("Invalid User");
+        }
 
         //refresh token rotate
         storedRefreshToken.setRevoked(true);


### PR DESCRIPTION
## Summary by Sourcery

Tighten refresh-token handling, adjust JWT role claims, and refine public vs. protected authentication endpoints and access control.

Bug Fixes:
- Validate that the refresh token’s user ID matches the stored token’s user before issuing a new token.

Enhancements:
- Add logging around refresh token generation, cookie attachment, and refresh processing for easier debugging.
- Change refresh-token JWT role claims to include the ROLE_ prefix expected by Spring Security.
- Restrict unauthenticated auth endpoints to only login and registration instead of all /api/auth/**.
- Allow POST access to the /api/v3/auth/refresh endpoint only for users with the DEVELOPER role.